### PR TITLE
Remove an unused expression

### DIFF
--- a/examples/function_calling.py
+++ b/examples/function_calling.py
@@ -15,8 +15,6 @@ data = {
     "payment_status": ["Paid", "Unpaid", "Paid", "Paid", "Pending"],
 }
 
-n_rows = len(data["transaction_id"])
-
 def retrieve_payment_status(data: Dict[str,List], transaction_id: str) -> str:
     for i, r in enumerate(data["transaction_id"]):
         if r == transaction_id:


### PR DESCRIPTION
While I was [porting the client to Ruby](https://github.com/wilsonsilva/mistral), I realised that the variable `n_rows` is not used anywhere. Thus, this whole expression can be removed.